### PR TITLE
Guard HSES tempdir cleanup when unzip was never called

### DIFF
--- a/src/pir_pipeline/hses/HSES.py
+++ b/src/pir_pipeline/hses/HSES.py
@@ -34,7 +34,7 @@ class HSES:
         self.__auth: tuple[str, str] = (self.__user, self.__key)
         self.__url: str = url
         self.__content: BytesIO
-        self.__tempdir: str
+        self.__tempdir: Optional[str] = None
 
     @property
     def content(self):
@@ -137,7 +137,9 @@ class HSES:
         Returns:
             Self: The instance of the class.
         """
-        shutil.rmtree(self.__tempdir)
+        if self.__tempdir is not None:
+            shutil.rmtree(self.__tempdir)
+            self.__tempdir = None
         return self
 
     def __del__(self):

--- a/tests/hses/test_HSES.py
+++ b/tests/hses/test_HSES.py
@@ -1,0 +1,18 @@
+import pytest
+
+from pir_pipeline.hses.HSES import HSES
+
+
+@pytest.fixture
+def hses_env(monkeypatch):
+    monkeypatch.setenv("HSES_API_USER", "test-user")
+    monkeypatch.setenv("HSES_API_KEY_PROD", "test-key")
+
+
+def test_clean_up_tempdir_before_unzip_is_a_safe_noop(hses_env):
+    # A freshly constructed HSES has no temporary directory yet (unzip was
+    # never called). Cleaning up should be a no-op instead of raising
+    # AttributeError. This also protects __del__, which calls this method on
+    # garbage collection.
+    hses = HSES()
+    hses.clean_up_tempdir()


### PR DESCRIPTION
Small fix I hit while reading through the HSES client.

`clean_up_tempdir()` runs `shutil.rmtree(self.__tempdir)`, but `__tempdir` is only set inside `unzip()`. If an HSES instance is created but never unzipped (for example `get_data()` raising before `unzip()` runs), the attribute is unset and `clean_up_tempdir()` raises `AttributeError: 'HSES' object has no attribute '_HSES__tempdir'`. Since `__del__` calls the same method, it also shows up as an "Exception ignored in __del__" traceback when the object is garbage collected.

The change initializes `__tempdir` to `None` and skips removal when there is nothing to clean up, which also makes the method idempotent (a second call is a no-op). The happy path still removes a real tempdir.

Added a regression test under tests/hses that constructs an HSES and calls `clean_up_tempdir()` without unzipping. It fails on main with the AttributeError and passes with this change. Ran it locally on Python 3.12.

Thanks for maintaining this.